### PR TITLE
Disconnect when queue ends

### DIFF
--- a/src/events/client/VoiceStateUpdate.ts
+++ b/src/events/client/VoiceStateUpdate.ts
@@ -94,7 +94,7 @@ export default class VoiceStateUpdate extends Event {
 			if (!(vc && vc.members instanceof Map)) return;
 
 			if (vc.members instanceof Map && [...vc.members.values()].filter((x: GuildMember) => !x.user.bot).length <= 0) {
-				setTimeout(async () => {
+                                setTimeout(async () => {
 					if (!player?.voiceChannelId) return;
 
 					const playerVoiceChannel = newState.guild.channels.cache.get(player?.voiceChannelId);
@@ -108,7 +108,7 @@ export default class VoiceStateUpdate extends Event {
 							player.destroy();
 						}
 					}
-				}, 5000);
+                                }, 60_000);
 			}
 		},
 

--- a/src/events/player/QueueEnd.ts
+++ b/src/events/player/QueueEnd.ts
@@ -27,12 +27,23 @@ export default class QueueEnd extends Event {
 		});
 		if (!message) return;
 
-		if (message.editable) {
-			await message.edit({ components: [] }).catch(() => {
-				null;
-			});
-		}
-	}
+                if (message.editable) {
+                        await message.edit({ components: [] }).catch(() => {
+                                null;
+                        });
+                }
+
+                const existing = player.get<NodeJS.Timeout>('disconnectTimeout');
+                if (existing) clearTimeout(existing);
+
+                const timeout = setTimeout(() => {
+                        if (!player.playing && player.queue.tracks.length === 0) {
+                                player.destroy();
+                        }
+                }, 60_000);
+
+                player.set('disconnectTimeout', timeout);
+        }
 }
 
 /**

--- a/src/events/player/TrackStart.ts
+++ b/src/events/player/TrackStart.ts
@@ -26,12 +26,17 @@ export default class TrackStart extends Event {
 		});
 	}
 
-	public async run(player: Player, track: Track | null, _payload: TrackStartEvent): Promise<void> {
-		const guild = this.client.guilds.cache.get(player.guildId);
-		if (!guild) return;
-		if (!player.textChannelId) return;
-		if (!track) return;
-		const channel = guild.channels.cache.get(player.textChannelId) as TextChannel;
+        public async run(player: Player, track: Track | null, _payload: TrackStartEvent): Promise<void> {
+                const guild = this.client.guilds.cache.get(player.guildId);
+                if (!guild) return;
+                const pending = player.get<NodeJS.Timeout>('disconnectTimeout');
+                if (pending) {
+                        clearTimeout(pending);
+                        player.set('disconnectTimeout', undefined);
+                }
+                if (!player.textChannelId) return;
+                if (!track) return;
+                const channel = guild.channels.cache.get(player.textChannelId) as TextChannel;
 		if (!channel) return;
 
 		this.client.utils.updateStatus(this.client, guild.id);


### PR DESCRIPTION
## Summary
- disconnect player after one minute of inactivity
- cancel disconnect when a new track starts

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: tsup not found)*

------
